### PR TITLE
IMPORTANT fabric loader update

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx1G
 # check these on https://fabricmc.net/versions.html
 minecraft_version=1.18
 yarn_mappings=1.18+build.1
-loader_version=0.12.8
+loader_version=0.12.9
 # Mod Properties
 mod_version=1.0.0
 maven_group=be.uantwepren


### PR DESCRIPTION
A remote code execution exploit potentially affecting versions of Minecraft has been discovered. As this exploit allows for running anything on any unpatched server or client and can be taken advantage of via chat messages.

In the meantime, you can work around this issue with the latest version of Fabric Loader (0.12.9), the latest version of Paper (if you run a server), or by adding  -Dlog4j2.formatMsgNoLookups=true to the JVM arguments in your launcher or server startup script.