### PR TITLE
Block/Item/Fluid Tags

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version=1.18
-yarn_mappings=1.18+build.1
-loader_version=0.12.9
+minecraft_version=1.18.1
+yarn_mappings=1.18.1+build.22
+loader_version=0.13.1
 # Mod Properties
 mod_version=1.0.0
 maven_group=be.uantwepren
 archives_base_name=Scicraft
 # Dependencies
-fabric_version=0.44.0+1.18
-wthit_version=4.3.0
+fabric_version=0.46.4+1.18
+wthit_version=4.5.1

--- a/src/main/java/be/uantwerpen/scicraft/item/ItemGroups.java
+++ b/src/main/java/be/uantwerpen/scicraft/item/ItemGroups.java
@@ -2,11 +2,17 @@ package be.uantwerpen.scicraft.item;
 
 import be.uantwerpen.scicraft.Scicraft;
 import net.fabricmc.fabric.api.client.itemgroup.FabricItemGroupBuilder;
+import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
-import net.minecraft.item.ItemGroup;
 
 public class ItemGroups {
+
+    public static final ItemGroup SCICRAFT_MISC = FabricItemGroupBuilder.create(
+                    new Identifier(Scicraft.MOD_ID, "scicraft_misc"))
+            .icon(() -> new ItemStack(net.minecraft.item.Items.HONEYCOMB))
+            .build();
+
     public static final ItemGroup QUANTUM_FIELDS = FabricItemGroupBuilder.create(
                     new Identifier(Scicraft.MOD_ID, "quantum_fields"))
             .icon(() -> new ItemStack(Items.ELECTRON))

--- a/src/main/java/be/uantwerpen/scicraft/item/Items.java
+++ b/src/main/java/be/uantwerpen/scicraft/item/Items.java
@@ -6,24 +6,30 @@ import be.uantwerpen.scicraft.entity.Entities;
 import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
-import net.minecraft.item.ItemGroup;
 import net.minecraft.item.SpawnEggItem;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 
 public class Items {
     // Items
-    public static final Item ELECTRON = register(new ElectronItem(new Item.Settings().group(ItemGroup.MISC).maxCount(64)), "electron");
-    public static final Item PROTON = register(new ProtonItem(new Item.Settings().group(ItemGroup.MISC).maxCount(64)), "proton");
-    public static final Item NEUTRON = register(new NeutronItem(new Item.Settings().group(ItemGroup.MISC).maxCount(64)), "neutron");
+    public static final Item ELECTRON = register(new ElectronItem(new Item.Settings()
+            .group(ItemGroups.QUANTUM_FIELDS).maxCount(64)), "electron");
+    public static final Item PROTON = register(new ProtonItem(new Item.Settings()
+            .group(ItemGroups.QUANTUM_FIELDS).maxCount(64)), "proton");
+    public static final Item NEUTRON = register(new NeutronItem(new Item.Settings()
+            .group(ItemGroups.QUANTUM_FIELDS).maxCount(64)), "neutron");
 
     public static final Item ENTROPY_CREEPER_SPAWN_EGG = register(new SpawnEggItem(Entities.ENTROPY_CREEPER,
-            0xbb64e1, 0x5d0486, new FabricItemSettings().group(ItemGroup.MISC)), "entropy_creeper_spawn_egg");
+                    0xbb64e1, 0x5d0486, new FabricItemSettings().group(ItemGroups.SCICRAFT_MISC)),
+            "entropy_creeper_spawn_egg");
 
     // BlockItems
-    public static final Item PION_NUL = register(new BlockItem(Blocks.PION_NUL, new FabricItemSettings().group(ItemGroups.ELEMENTARY_PARTICLES)), "pion_nul");
-    public static final Item PION_MINUS = register(new BlockItem(Blocks.PION_MINUS, new FabricItemSettings().group(ItemGroups.ELEMENTARY_PARTICLES)), "pion_minus");
-    public static final Item PION_PLUS = register(new BlockItem(Blocks.PION_PLUS, new FabricItemSettings().group(ItemGroups.ELEMENTARY_PARTICLES)), "pion_plus");
+    public static final Item PION_NUL = register(new BlockItem(Blocks.PION_NUL,
+            new FabricItemSettings().group(ItemGroups.ELEMENTARY_PARTICLES)), "pion_nul");
+    public static final Item PION_MINUS = register(new BlockItem(Blocks.PION_MINUS,
+            new FabricItemSettings().group(ItemGroups.ELEMENTARY_PARTICLES)), "pion_minus");
+    public static final Item PION_PLUS = register(new BlockItem(Blocks.PION_PLUS,
+            new FabricItemSettings().group(ItemGroups.ELEMENTARY_PARTICLES)), "pion_plus");
 
     /**
      * Register an Item

--- a/src/main/java/be/uantwerpen/scicraft/util/Tags.java
+++ b/src/main/java/be/uantwerpen/scicraft/util/Tags.java
@@ -36,8 +36,6 @@ public class Tags {
 
     public static class Items {
 
-        public static final Tag<Item> COPPER_BLOCKS = createTag("copper_blocks");
-
         /**
          * Create an Item tag (tag is only used inside this mod)
          * Don't forget the json file (data/scicraft/items)

--- a/src/main/java/be/uantwerpen/scicraft/util/Tags.java
+++ b/src/main/java/be/uantwerpen/scicraft/util/Tags.java
@@ -1,0 +1,88 @@
+package be.uantwerpen.scicraft.util;
+
+import be.uantwerpen.scicraft.Scicraft;
+import net.fabricmc.fabric.api.tag.TagFactory;
+import net.minecraft.block.Block;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.item.Item;
+import net.minecraft.tag.Tag;
+import net.minecraft.util.Identifier;
+
+public class Tags {
+    public static class Blocks {
+
+        /**
+         * Create a Block tag (tag is only used inside this mod)
+         * Don't forget the json file (data/scicraft/blocks)
+         *
+         * @param name : name of the tag
+         * @return {@link Tag}
+         */
+        private static Tag<Block> createTag(String name) {
+            return TagFactory.BLOCK.create(new Identifier(Scicraft.MOD_ID, name));
+        }
+
+        /**
+         * Create a Block tag (tag for usage outside this mod)
+         * Don't forget the json file (data/c/blocks)
+         *
+         * @param name : name of the tag
+         * @return {@link Tag}
+         */
+        private static Tag<Block> createCommonTag(String name) {
+            return TagFactory.BLOCK.create(new Identifier("c", name));
+        }
+    }
+
+    public static class Items {
+
+        public static final Tag<Item> COPPER_BLOCKS = createTag("copper_blocks");
+
+        /**
+         * Create an Item tag (tag is only used inside this mod)
+         * Don't forget the json file (data/scicraft/items)
+         *
+         * @param name : name of the tag
+         * @return {@link Tag}
+         */
+        private static Tag<Item> createTag(String name) {
+            return TagFactory.ITEM.create(new Identifier(Scicraft.MOD_ID, name));
+        }
+
+        /**
+         * Create an Item tag (tag for usage outside this mod)
+         * Don't forget the json file (data/c/items)
+         *
+         * @param name : name of the tag
+         * @return {@link Tag}
+         */
+        private static Tag<Item> createCommonTag(String name) {
+            return TagFactory.ITEM.create(new Identifier("c", name));
+        }
+    }
+
+    public static class Fluids {
+
+        /**
+         * Create a Fluid tag (tag is only used inside this mod)
+         * Don't forget the json file (data/scicraft/items)
+         *
+         * @param name : name of the tag
+         * @return {@link Tag}
+         */
+        private static Tag<Fluid> createTag(String name) {
+            return TagFactory.FLUID.create(new Identifier(Scicraft.MOD_ID, name));
+        }
+
+        /**
+         * Create a Fluid tag (tag for usage outside this mod)
+         * Don't forget the json file (data/c/items)
+         *
+         * @param name : name of the tag
+         * @return {@link Tag}
+         */
+        private static Tag<Fluid> createCommonTag(String name) {
+            return TagFactory.FLUID.create(new Identifier("c", name));
+        }
+    }
+}

--- a/src/main/resources/assets/scicraft/lang/en_us.json
+++ b/src/main/resources/assets/scicraft/lang/en_us.json
@@ -1,11 +1,10 @@
 {
   "itemGroup.scicraft.quantum_fields": "Quantum Fields",
   "itemGroup.scicraft.elementary_particles": "Elementary Particles",
-
+  "itemGroup.scicraft.scicraft_misc": "Scicraft Miscellaneous",
   "block.scicraft.pion_nul": "Pion Nul",
   "block.scicraft.pion_minus": "Pion Minus",
   "block.scicraft.pion_plus": "Pion Plus",
-
   "item.scicraft.proton": "Proton",
   "item.scicraft.electron": "Electron",
   "item.scicraft.neutron": "Neutron",
@@ -13,5 +12,8 @@
   "item.scicraft.pion_minus": "Pion Minus",
   "item.scicraft.pion_plus": "Pion Plus",
   "item.scicraft.entropy_creeper_spawn_egg": "Entropy Creeper Spawn Egg",
-  "entity.scicraft.entropy_creeper": "Entropy Creeper"
+  "entity.scicraft.entropy_creeper": "Entropy Creeper",
+  "entity.scicraft.electron_entity": "Flying Electron",
+  "entity.scicraft.proton_entity": "Flying Proton",
+  "entity.scicraft.neutron_entity": "Flying Neutron"
 }

--- a/src/main/resources/assets/scicraft/lang/nl_be.json
+++ b/src/main/resources/assets/scicraft/lang/nl_be.json
@@ -1,11 +1,10 @@
 {
   "itemGroup.scicraft.quantum_fields": "Kwantumvelden",
   "itemGroup.scicraft.elementary_particles": "Elementaire Deeltjes",
-  
+  "itemGroup.scicraft.scicraft_misc": "Scicraft Diversen",
   "block.scicraft.pion_nul": "Pion Nul",
   "block.scicraft.pion_minus": "Pion Min",
   "block.scicraft.pion_plus": "Pion Plus",
-
   "item.scicraft.neutron": "Neutron",
   "item.scicraft.electron": "Elektron",
   "item.scicraft.proton": "Proton",
@@ -13,5 +12,8 @@
   "item.scicraft.pion_minus": "Pion Min",
   "item.scicraft.pion_plus": "Pion Plus",
   "item.scicraft.entropy_creeper_spawn_egg": "Entropy Creeperspawnei",
-  "entity.scicraft.entropy_creeper": "Entropy Creeper"
+  "entity.scicraft.entropy_creeper": "Entropy Creeper",
+  "entity.scicraft.electron_entity": "Vliegend Elektron",
+  "entity.scicraft.proton_entity": "Vliegend Proton",
+  "entity.scicraft.neutron_entity": "Vliegend Neutron"
 }

--- a/src/main/resources/data/scicraft/blocks/block_tag.json
+++ b/src/main/resources/data/scicraft/blocks/block_tag.json
@@ -1,0 +1,7 @@
+{
+  "repalce": false,
+  "values": [
+    "minecraft:iron_block",
+    "scicraft:pion_nul"
+  ]
+}

--- a/src/main/resources/data/scicraft/fluids/fluid_tag.json
+++ b/src/main/resources/data/scicraft/fluids/fluid_tag.json
@@ -1,0 +1,6 @@
+{
+  "repalce": false,
+  "values": [
+    "minecraft:lava"
+  ]
+}

--- a/src/main/resources/data/scicraft/items/item_tag.json
+++ b/src/main/resources/data/scicraft/items/item_tag.json
@@ -1,0 +1,7 @@
+{
+  "repalce": false,
+  "values": [
+    "minecraft:iron_block",
+    "scicraft:pion_nul"
+  ]
+}


### PR DESCRIPTION
Added base methods for easy Tag registration.
example: `public static final Tag<Block> RUBIES = createCommonTag("rubies");`
json file should look like (filename: "rubies.json"):
`{"replace": false,
"values": [ ]
}`
With the empty list containing all the items/blocks/items you want to have this tag.